### PR TITLE
Persistence for Quests and Followers

### DIFF
--- a/functions/fb.js
+++ b/functions/fb.js
@@ -30,11 +30,13 @@ exports.handler = async (event) => {
           .collection('users')
           .doc(event.body)
           .set({
+            registered: new Date(),
             followers: [
-              { id: 1, name: 'Rick Sanchez' },
-              { id: 2, name: 'Morty Smith' },
-              { id: 3, name: 'Beth Smith' },
+              { id: 1, acquired: new Date() },
+              { id: 2, acquired: new Date() },
+              { id: 3, acquired: new Date() },
             ],
+            quests: [],
           })
           .then((res) => console.log(res))
           .catch((err) => console.log(err));

--- a/src/components/QuestLog/QuestLog.js
+++ b/src/components/QuestLog/QuestLog.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import {
   FinishedQuests,
-  ActiveQuests,
+  // ActiveQuests,
   AvailableQuests,
   NoQuests,
 } from './styled';
@@ -13,7 +13,7 @@ import { GameContext } from 'context/game';
 const QuestLog = () => {
   const { quests } = useContext(GameContext);
 
-  const activeQuests = quests.filter((q) => q.active);
+  // const activeQuests = quests.filter((q) => q.active);
   const availableQuests = quests.filter((q) => !q.active && q.available);
   const finishedQuests = quests.filter((q) => q.finished);
 
@@ -26,7 +26,7 @@ const QuestLog = () => {
   return (
     <>
       <h1>Quests</h1>
-      <h2>Active</h2>
+      {/* <h2>Active</h2>
       <ActiveQuests>
         {activeQuests.length > 0 ? (
           activeQuests.map(({ id, follower, type }) => (
@@ -38,7 +38,7 @@ const QuestLog = () => {
         ) : (
           <NoQuests>No Active Quests</NoQuests>
         )}
-      </ActiveQuests>
+      </ActiveQuests> */}
       <h2>Available</h2>
       <AvailableQuests>
         {availableQuests.length > 0 ? (

--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -26,7 +26,7 @@ const SignIn = () => {
       })
       .then((res) => res.json().then((res) => console.log(res)))
       .catch((error) => {
-        console.log(error);
+        console.error(error);
       });
   };
 

--- a/src/context/game/Game.js
+++ b/src/context/game/Game.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 
 import allQuests from 'data/quests';
-import { gainFollower } from './firebase';
+import { persistFollower, persistQuest } from './firebase';
 import { AuthContext } from '../../context/AuthProvider';
 
 export const GameContext = React.createContext([]);
@@ -20,7 +20,8 @@ export const GameContextProvider = ({ children }) => {
       finished: true,
       available: false,
     };
-    gainFollower(index, currentUser.uid);
+    persistFollower(quest.follower.id, currentUser.uid);
+    persistQuest(index, currentUser.uid);
     setCharacters([...characters, quest.follower]);
     setQuests(newQuests);
   };

--- a/src/context/game/Game.js
+++ b/src/context/game/Game.js
@@ -1,24 +1,28 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 
 import allQuests from 'data/quests';
+import { gainFollower } from './firebase';
+import { AuthContext } from '../../context/AuthProvider';
 
 export const GameContext = React.createContext([]);
 
 export const GameContextProvider = ({ children }) => {
-  const [quests, setQuests] = useState(allQuests);
+  const { currentUser } = useContext(AuthContext);
 
+  const [quests, setQuests] = useState(allQuests);
   const [characters, setCharacters] = useState([]);
 
   const setQuestFinished = (quest) => {
-    const new_quests = [...quests];
-    const index = new_quests.findIndex((q) => q.id === quest.id);
-    new_quests[index] = {
-      ...new_quests[index],
+    const newQuests = [...quests];
+    const index = newQuests.findIndex((q) => q.id === quest.id);
+    newQuests[index] = {
+      ...newQuests[index],
       finished: true,
       available: false,
     };
+    gainFollower(index, currentUser.uid);
     setCharacters([...characters, quest.follower]);
-    setQuests(new_quests);
+    setQuests(newQuests);
   };
 
   return (

--- a/src/context/game/Game.js
+++ b/src/context/game/Game.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 
-import Quests from 'data/quests';
+import allQuests from 'data/quests';
 
 export const GameContext = React.createContext([]);
 
 export const GameContextProvider = ({ children }) => {
-  const [quests, setQuests] = useState(Quests);
+  const [quests, setQuests] = useState(allQuests);
 
   const [characters, setCharacters] = useState([]);
 

--- a/src/context/game/firebase.js
+++ b/src/context/game/firebase.js
@@ -1,7 +1,7 @@
 import { db } from '../../base';
 
-export const persistFollower = async (fid, uid) => {
-  const oldFollowers = await db
+export const getFollowersFromDB = async (uid) => {
+  const followers = await db
     .collection('users')
     .doc(uid)
     .get()
@@ -9,6 +9,25 @@ export const persistFollower = async (fid, uid) => {
       return res.data().followers;
     })
     .catch((err) => console.error(err));
+
+  return followers;
+};
+
+export const getQuestsFromDB = async (uid) => {
+  const quests = await db
+    .collection('users')
+    .doc(uid)
+    .get()
+    .then((res) => {
+      return res.data().quests;
+    })
+    .catch((err) => console.error(err));
+
+  return quests;
+};
+
+export const persistFollower = async (fid, uid) => {
+  const oldFollowers = await getFollowersFromDB(uid);
 
   return db
     .collection('users')
@@ -19,14 +38,7 @@ export const persistFollower = async (fid, uid) => {
 };
 
 export const persistQuest = async (qid, uid) => {
-  const oldQuests = await db
-    .collection('users')
-    .doc(uid)
-    .get()
-    .then((res) => {
-      return res.data().quests;
-    })
-    .catch((err) => console.error(err));
+  const oldQuests = await getQuestsFromDB(uid);
 
   return db
     .collection('users')

--- a/src/context/game/firebase.js
+++ b/src/context/game/firebase.js
@@ -1,6 +1,6 @@
 import { db } from '../../base';
 
-export const gainFollower = async (fid, uid) => {
+export const persistFollower = async (fid, uid) => {
   const oldFollowers = await db
     .collection('users')
     .doc(uid)
@@ -13,7 +13,25 @@ export const gainFollower = async (fid, uid) => {
   return db
     .collection('users')
     .doc(uid)
-    .set({
+    .update({
       followers: [...oldFollowers, { id: fid, acquired: new Date() }],
+    });
+};
+
+export const persistQuest = async (qid, uid) => {
+  const oldQuests = await db
+    .collection('users')
+    .doc(uid)
+    .get()
+    .then((res) => {
+      return res.data().quests;
+    })
+    .catch((err) => console.error(err));
+
+  return db
+    .collection('users')
+    .doc(uid)
+    .update({
+      quests: [...oldQuests, { id: qid, finished: new Date() }],
     });
 };

--- a/src/context/game/firebase.js
+++ b/src/context/game/firebase.js
@@ -1,0 +1,19 @@
+import { db } from '../../base';
+
+export const gainFollower = async (fid, uid) => {
+  const oldFollowers = await db
+    .collection('users')
+    .doc(uid)
+    .get()
+    .then((res) => {
+      return res.data().followers;
+    })
+    .catch((err) => console.error(err));
+
+  return db
+    .collection('users')
+    .doc(uid)
+    .set({
+      followers: [...oldFollowers, { id: fid, acquired: new Date() }],
+    });
+};

--- a/src/data/followers.js
+++ b/src/data/followers.js
@@ -1,10 +1,30 @@
+const startingFollowers = [
+  {
+    id: 1,
+    name: 'Rick Sanchez',
+    api: 'https://rickandmortyapi.com/api/character/1',
+    image: 'https://rickandmortyapi.com/api/character/avatar/1.jpeg',
+  },
+  {
+    id: 2,
+    name: 'Morty Smith',
+    api: 'https://rickandmortyapi.com/api/character/2',
+    image: 'https://rickandmortyapi.com/api/character/avatar/2.jpeg',
+  },
+  {
+    id: 3,
+    name: 'Summer Smith',
+    api: 'https://rickandmortyapi.com/api/character/3',
+    image: 'https://rickandmortyapi.com/api/character/avatar/3.jpeg',
+  },
+];
+
 const adventureFollowers = [
   {
     id: 126,
     name: 'Fleeb',
     api: 'https://rickandmortyapi.com/api/character/126',
     image: 'https://rickandmortyapi.com/api/character/avatar/126.jpeg',
-
     modifier: 15,
   },
   {
@@ -12,7 +32,6 @@ const adventureFollowers = [
     name: 'Hepatitis C',
     api: 'https://rickandmortyapi.com/api/character/99',
     image: 'https://rickandmortyapi.com/api/character/avatar/99.jpeg',
-
     modifier: 20,
   },
   {
@@ -30,7 +49,6 @@ const quizFollowers = [
     name: 'Mechanical Summer',
     api: 'https://rickandmortyapi.com/api/character/219',
     image: 'https://rickandmortyapi.com/api/character/avatar/219.jpeg',
-
     modifier: 10,
   },
   {
@@ -38,7 +56,6 @@ const quizFollowers = [
     name: 'Dancer Morty',
     api: 'https://rickandmortyapi.com/api/character/475',
     image: 'https://rickandmortyapi.com/api/character/avatar/475.jpeg',
-
     modifier: 15,
   },
   {
@@ -46,9 +63,14 @@ const quizFollowers = [
     name: 'Zeta Alpha Rick',
     api: 'https://rickandmortyapi.com/api/character/389',
     image: 'https://rickandmortyapi.com/api/character/avatar/389.jpeg',
-
     modifier: 15,
   },
 ];
 
-export { adventureFollowers, quizFollowers };
+const allFollowers = [
+  ...startingFollowers,
+  ...quizFollowers,
+  ...adventureFollowers,
+];
+
+export { allFollowers, adventureFollowers, quizFollowers };

--- a/src/data/quests.js
+++ b/src/data/quests.js
@@ -1,8 +1,8 @@
-import adventures from './adventures';
+// import adventures from './adventures';
 
 import questions from './questions';
 
-import { quizFollowers, adventureFollowers } from './followers';
+import { quizFollowers /*, adventureFollowers */ } from './followers';
 
 const quiz_quests = quizFollowers.map((follower, index) => ({
   id: 'quiz-' + index,
@@ -15,17 +15,17 @@ const quiz_quests = quizFollowers.map((follower, index) => ({
   questions: [questions[index]],
 }));
 
-const adventure_quests = quizFollowers.map((follower, index) => ({
-  id: 'adventure-' + index,
+// const adventure_quests = quizFollowers.map((follower, index) => ({
+//   id: 'adventure-' + index,
 
-  type: 'adventure',
-  active: false,
-  available: true,
-  finished: false,
-  follower: adventureFollowers[index],
-  adventure: adventures[index],
-}));
+//   type: 'adventure',
+//   active: false,
+//   available: true,
+//   finished: false,
+//   follower: adventureFollowers[index],
+//   adventure: adventures[index],
+// }));
 
-const quests = [...quiz_quests, ...adventure_quests];
+const quests = [...quiz_quests /*, ...adventure_quests*/];
 
 export default quests;

--- a/src/data/quests.js
+++ b/src/data/quests.js
@@ -7,7 +7,7 @@ import { quizFollowers /*, adventureFollowers */ } from './followers';
 const quiz_quests = quizFollowers.map((follower, index) => ({
   id: 'quiz-' + index,
   type: 'quiz',
-  active: false,
+  // active: false,
   available: true,
   finished: false,
 


### PR DESCRIPTION
I added all the logic for the persistence of Followers and Quests in the Firestore/DB. I think we need to rethink some of the data models in one of the next steps, but for now it works. There's also a structure for user data on the database now.