### PR TITLE
Show initial followers, closes #31

### DIFF
--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -48,7 +48,7 @@ const SignIn = () => {
         <GoogleButton onClick={signIn}>
           <GoogleIconWrapper>
             <GoogleIcon
-              class="google-icon"
+              className="google-icon"
               src="https://upload.wikimedia.org/wikipedia/commons/5/53/Google_%22G%22_Logo.svg"
             />
           </GoogleIconWrapper>

--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -13,9 +13,11 @@ import {
 import { ReactComponent as LogoSVG } from 'assets/rick.svg';
 import app from '../../base';
 import { AuthContext } from 'context/AuthContext';
+import { GameContext } from 'context/GameContext';
 
 const SignIn = () => {
   const { currentUser } = useContext(AuthContext);
+  const { refreshData } = useContext(GameContext);
   const provider = new firebase.auth.GoogleAuthProvider();
 
   const signIn = () => {
@@ -32,6 +34,7 @@ const SignIn = () => {
         });
       })
       .then((res) => res.json().then((res) => console.log(res)))
+      .then(() => refreshData())
       .catch((error) => {
         console.error(error);
       });

--- a/src/context/GameContext.js
+++ b/src/context/GameContext.js
@@ -22,8 +22,10 @@ export const GameContextProvider = ({ children }) => {
   }, [currentUser]);
 
   function refreshData() {
-    getUserCharacters(currentUser.uid).then((res) => setFollowers(res));
-    getUserQuizzes(currentUser.uid).then((res) => setQuizzes(res));
+    if (currentUser) {
+      getUserCharacters(currentUser.uid).then((res) => setFollowers(res));
+      getUserQuizzes(currentUser.uid).then((res) => setQuizzes(res));
+    }
   }
 
   return (


### PR DESCRIPTION
This is the bugfix for Issue #31. Fixed by refreshing the user data in the callback of the sign up function promise. Needed to add a `currentUser`-check to it, because for some reason it would occasionally be called with an empty user object before properly being called, resulting in an error message in the console.